### PR TITLE
adapt package for Heroku to execute build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "build": "NODE_ENV=production webpack --config ./webpack.config.js --progress --colors",
     "test": "export NODE_ENV=test; test",
     "start:dev": "export NODE_ENV=development; nodemon ./bin/www",
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "heroku-postbuild": "echo Skip build on Heroku"
   },
+  "heroku-run-build-script": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wedesignstudios/we-portfolio.git"


### PR DESCRIPTION
Adds `heroku-postbuild` and `heroku-run-build-script` keys to conform with upcoming changes to  Heroku's Node.js buildpack